### PR TITLE
修复 某款摄像头国标 心跳标签 的问题，导致 只要设备发送心跳包，这个设备就会离线

### DIFF
--- a/pkg/gbs/keepalive.go
+++ b/pkg/gbs/keepalive.go
@@ -4,16 +4,20 @@ import (
 	"github.com/gowvp/owl/internal/core/ipc"
 	"github.com/gowvp/owl/pkg/gbs/sip"
 	"github.com/ixugo/goddd/pkg/orm"
-	// "github.com/panjjo/gosip/db"
 )
 
-// MessageNotify 心跳包xml结构
+// MessageNotify 心跳包 XML 结构
 type MessageNotify struct {
-	CmdType  string `xml:"CmdType"`
-	SN       int    `xml:"SN"`
-	DeviceID string `xml:"DeviceID"`
-	Status   string `xml:"Status"`
-	Info     string `xml:"Info"`
+	CmdType  string        `xml:"CmdType"`
+	SN       int           `xml:"SN"`
+	DeviceID string        `xml:"DeviceID"`
+	Status   string        `xml:"Status"` // 国标标准格式：Status 在根级别
+	Info     KeepaliveInfo `xml:"Info"`   // 部分厂商（如海康）将 Status 嵌套在 Info 中
+}
+
+// KeepaliveInfo 部分厂商心跳包中 Info 子元素
+type KeepaliveInfo struct {
+	Status string `xml:"Status"`
 }
 
 func (g *GB28181API) sipMessageKeepalive(ctx *sip.Context) {
@@ -23,8 +27,13 @@ func (g *GB28181API) sipMessageKeepalive(ctx *sip.Context) {
 		return
 	}
 
-	// 程序重启时会丢内存，收到 keepalive 时，补上
-	// 并未补充到
+	// 兼容两种 Status 位置：国标根级别 / 部分厂商嵌套在 Info 中
+	status := msg.Status
+	if status == "" {
+		status = msg.Info.Status
+	}
+
+	// 程序重启后内存丢失，收到 keepalive 时补上
 	g.svr.memoryStorer.LoadOrStore(ctx.DeviceID, &Device{
 		conn:   ctx.Request.GetConnection(),
 		source: ctx.Source,
@@ -34,7 +43,7 @@ func (g *GB28181API) sipMessageKeepalive(ctx *sip.Context) {
 
 	if err := g.svr.memoryStorer.Change(ctx.DeviceID, func(d *ipc.Device) error {
 		d.KeepaliveAt = orm.Now()
-		d.IsOnline = msg.Status == "OK" || msg.Status == "ON"
+		d.IsOnline = status == "OK" || status == "ON"
 		d.Address = ctx.Source.String()
 		d.Transport = ctx.Source.Network()
 		return nil


### PR DESCRIPTION
海康的某款摄像头 的心跳包
<?xml version="1.0" encoding="gb2312"?>
<Notify>
    <CmdType>Keepalive</CmdType>
    <SN>730</SN>
    <DeviceID>34020000002000000003</DeviceID>
    <Info>
        <Status>OK</Status>
    </Info>
</Notify>
和国标不太一样，就会导致 摄像头发送心跳包就离线